### PR TITLE
Add course management and user roles for LMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The Classroom-Template repository is intended to serve as a starting point for e
 - 🛠️ **Comprehensive Backend**: Built with Django, featuring RESTful APIs and database models for managing student data.
 - 🎨 **Interactive Frontend**: Developed with React, providing an intuitive user interface for registration and profile management.
 - 📚 **Extensive Documentation**: Includes guides for API usage, system architecture, and deployment processes.
+- 📘 **Course Management**: Supports self-paced and instructor-led courses with roles for students, instructors, staff, and customers.
 
 ---
 

--- a/backend/surms_backend/api/urls.py
+++ b/backend/surms_backend/api/urls.py
@@ -1,7 +1,18 @@
 from django.urls import path
-from .views import StudentListCreate, StudentDetail
+from ..views import (
+    StudentListCreate,
+    StudentDetail,
+    CourseListCreate,
+    CourseDetail,
+    UserProfileListCreate,
+    UserProfileDetail,
+)
 
 urlpatterns = [
     path('students/', StudentListCreate.as_view(), name='student-list-create'),
     path('students/<int:pk>/', StudentDetail.as_view(), name='student-detail'),
+    path('courses/', CourseListCreate.as_view(), name='course-list-create'),
+    path('courses/<int:pk>/', CourseDetail.as_view(), name='course-detail'),
+    path('users/', UserProfileListCreate.as_view(), name='userprofile-list-create'),
+    path('users/<int:pk>/', UserProfileDetail.as_view(), name='userprofile-detail'),
 ]

--- a/backend/surms_backend/models.py
+++ b/backend/surms_backend/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 class Student(models.Model):
     github_username = models.CharField(max_length=100, unique=True)
@@ -8,3 +9,52 @@ class Student(models.Model):
 
     def __str__(self):
         return self.github_username
+
+
+class UserProfile(models.Model):
+    ROLE_CHOICES = [
+        ("student", "Student"),
+        ("instructor", "Instructor"),
+        ("staff", "Staff"),
+        ("customer", "Customer"),
+    ]
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
+    role = models.CharField(max_length=20, choices=ROLE_CHOICES)
+
+    def __str__(self):
+        return f"{self.user.username} ({self.role})"
+
+
+class Course(models.Model):
+    COURSE_TYPES = [
+        ("self-paced", "Self-paced"),
+        ("instructor-led", "Instructor-led"),
+    ]
+    VENDOR_CHOICES = [
+        ("IBM", "IBM"),
+        ("MICROSOFT", "Microsoft"),
+        ("COMPTIA", "CompTIA"),
+        ("GOOGLE", "Google"),
+        ("AWS", "AWS"),
+        ("GITHUB", "GitHub"),
+        ("ORACLE", "Oracle"),
+        ("HPE", "HPE"),
+        ("DELL_EMC", "Dell/EMC"),
+        ("EC_COUNCIL", "EC-Council"),
+        ("PCEB", "PCEB"),
+        ("SAFE", "SAFe"),
+        ("BROADCOM", "Broadcom"),
+        ("CISCO", "CISCO"),
+        ("PALO_ALTO", "Palo Alto"),
+        ("FORTINET", "Fortinet"),
+        ("HUAWEI", "Huawei"),
+        ("CODING", "Coding"),
+    ]
+    title = models.CharField(max_length=200)
+    description = models.TextField(blank=True)
+    vendor = models.CharField(max_length=20, choices=VENDOR_CHOICES)
+    course_type = models.CharField(max_length=20, choices=COURSE_TYPES)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.title

--- a/backend/surms_backend/serializers.py
+++ b/backend/surms_backend/serializers.py
@@ -1,7 +1,19 @@
 from rest_framework import serializers
-from .models import Student
+from .models import Student, Course, UserProfile
 
 class StudentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Student
         fields = '__all__'
+
+
+class CourseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Course
+        fields = '__all__'
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = UserProfile
+        fields = ['id', 'user', 'role']

--- a/backend/surms_backend/settings.py
+++ b/backend/surms_backend/settings.py
@@ -54,12 +54,8 @@ ASGI_APPLICATION = 'surms_backend.asgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'surms_db',
-        'USER': 'your-db-user',
-        'PASSWORD': 'your-db-password',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
 

--- a/backend/surms_backend/tests/test_models.py
+++ b/backend/surms_backend/tests/test_models.py
@@ -1,7 +1,13 @@
 from django.test import TestCase
-from ..models import Student
+from ..models import Student, Course
 
 class StudentModelTest(TestCase):
     def test_string_representation(self):
         student = Student(github_username='testuser')
         self.assertEqual(str(student), student.github_username)
+
+
+class CourseModelTest(TestCase):
+    def test_string_representation(self):
+        course = Course(title='Intro AWS', vendor='AWS', course_type='self-paced')
+        self.assertEqual(str(course), course.title)

--- a/backend/surms_backend/tests/test_views.py
+++ b/backend/surms_backend/tests/test_views.py
@@ -1,11 +1,24 @@
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from ..models import Student
+from ..models import Student, Course
 
 class StudentTests(APITestCase):
     def test_create_student(self):
         url = reverse('student-list-create')
         data = {'github_username': 'testuser', 'email': 'test@example.com', 'full_name': 'Test User'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+
+class CourseTests(APITestCase):
+    def test_create_course(self):
+        url = reverse('course-list-create')
+        data = {
+            'title': 'Intro AWS',
+            'description': 'Basics of AWS',
+            'vendor': 'AWS',
+            'course_type': 'self-paced',
+        }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/backend/surms_backend/views.py
+++ b/backend/surms_backend/views.py
@@ -1,6 +1,6 @@
 from rest_framework import generics
-from .models import Student
-from .serializers import StudentSerializer
+from .models import Student, Course, UserProfile
+from .serializers import StudentSerializer, CourseSerializer, UserProfileSerializer
 
 class StudentListCreate(generics.ListCreateAPIView):
     queryset = Student.objects.all()
@@ -9,3 +9,23 @@ class StudentListCreate(generics.ListCreateAPIView):
 class StudentDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Student.objects.all()
     serializer_class = StudentSerializer
+
+
+class CourseListCreate(generics.ListCreateAPIView):
+    queryset = Course.objects.all()
+    serializer_class = CourseSerializer
+
+
+class CourseDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Course.objects.all()
+    serializer_class = CourseSerializer
+
+
+class UserProfileListCreate(generics.ListCreateAPIView):
+    queryset = UserProfile.objects.all()
+    serializer_class = UserProfileSerializer
+
+
+class UserProfileDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = UserProfile.objects.all()
+    serializer_class = UserProfileSerializer


### PR DESCRIPTION
## Summary
- switch backend database to SQLite for easy local setup
- add Course and UserProfile models with REST API endpoints
- expand tests for new course model and endpoint

## Testing
- `python manage.py test`
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e24a1af88333a168f27a2f4adbe7